### PR TITLE
Run minification process after webpack build at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If need to replace array of string with common replace funtions and then minify 
     const webpackConfig = {
         plugins: [
             new MinifyHtmlWebpackPlugin({
+                afterBuild: true,
                 src: './storage/framework/views',
                 dest: './storage/framework/views',
                 rules: {
@@ -120,6 +121,7 @@ Paste below snippets into mix.js file.
     mix.webpackConfig({
         plugins: [
             new MinifyHtmlWebpackPlugin({
+                afterBuild: true,
                 src: './storage/framework/views',
                 dest: './storage/framework/views',
                 ignoreFileNameRegex: /\.(gitignore|php)$/,
@@ -141,9 +143,10 @@ Configuration
 
 You can pass configuration options to `MinifyHtmlWebpackPlugin`. Each configuration has following items:
 
+- `afterBuild`: Optional. Add `afterBuild:true`, if you want to run complete minification process after webpack build, at the end.
 - `dir`: Optional. Base dir to find the files, if not provided, use the root of webpack context.
 - `src`: Required. source directory path.
-- `dest`: Optional. destination directory path. Paste minified HTML contents from `src` directory files into `dest` directory, if not provided, paste into `src` directory and will be overwritten.
+- `dest`: Required. destination directory path. Paste minified HTML contents from `src` directory files into `dest` directory.
 - `ignoreFileNameRegex`: Optional. Regex Expression to ingnore files in the src directory if it matches with the file name, if not provided, will minimize all files in src directory.`
 - `ignoreFileContentsRegex`: Optional. Regex Expression to ingnore files in the src directory if it matches with the file contents, if not provided, will minimize all files in src directory.`
 - `rules`: Required. See the [html-minifer docs](https://github.com/kangax/html-minifier) for all available options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minify-html-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A webpack plugin to minify html file(s) after building",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -39,7 +39,10 @@
     "searchstring",
     "replace",
     "replacestring",
-    "replacer"
+    "replacer",
+    "build",
+    "after",
+    "afterbuild"
   ],
   "author": {
     "name": "Ashutosh Kumar Jha",


### PR DESCRIPTION
**Option to run minification process at the end of webpack build hook.**

- `afterBuild`: Optional. Add `afterBuild:true`, if you want to run complete minification process after webpack build, at the end.